### PR TITLE
Add getNumberEnv for retrieving environment variables

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
-        "@types/bun": "^1.4.1",
+        "@types/bun": "^1.4.2",
         "typescript": "^7.0.2",
       },
     },
@@ -113,7 +113,7 @@
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
-        "@types/bun": "^1.4.1",
+        "@types/bun": "^1.4.2",
         "typescript": "^7.0.2",
       },
     },
@@ -159,7 +159,7 @@
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@happy-dom/global-registrator": "^20.14.0",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -173,7 +173,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -194,7 +194,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -234,7 +234,7 @@
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@happy-dom/global-registrator": "^20.14.0",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -282,13 +282,14 @@
       "name": "@alwatr/env",
       "version": "10.1.0",
       "dependencies": {
+        "@alwatr/is-number": "workspace:*",
         "@alwatr/platform-info": "workspace:*",
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -299,7 +300,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -350,7 +351,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -458,7 +459,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -479,7 +480,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -518,7 +519,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -614,7 +615,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -628,7 +629,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -642,7 +643,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -660,7 +661,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -681,7 +682,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -697,7 +698,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -719,7 +720,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -733,7 +734,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -752,7 +753,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "typescript": "^7.0.2",
       },
     },
@@ -804,7 +805,7 @@
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
-        "@types/bun": "^1.4.1",
+        "@types/bun": "^1.4.2",
         "typescript": "^7.0.2",
       },
     },
@@ -936,19 +937,19 @@
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.14.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.14.0" } }, "sha512-Xn0kdkaA1eHOaFFopr+YQ37sPNTZ3JScpUMz3j4rIsn1Nneqoh94z79iW23Ej0Ytt99+LlFr4JrSDd6ow9c7MQ=="],
 
-    "@inquirer/ansi": ["@inquirer/ansi@2.0.7", "", {}, "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q=="],
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.8", "", {}, "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ=="],
 
-    "@inquirer/core": ["@inquirer/core@12.0.0", "", { "dependencies": { "@inquirer/ansi": "^2.0.7", "@inquirer/figures": "^2.0.8", "@inquirer/type": "^4.0.7", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA=="],
+    "@inquirer/core": ["@inquirer/core@12.0.3", "", { "dependencies": { "@inquirer/ansi": "^2.0.8", "@inquirer/figures": "^2.0.9", "@inquirer/type": "4.1.1", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-wsSy0sznmXwkty+2PzZwx00Cazc/E0r0B7mAzdGROz2Ct+DFZXaK7WDjGZvgjRldxH5ZhFVfF2lgkYrqgOw2KA=="],
 
-    "@inquirer/expand": ["@inquirer/expand@5.1.2", "", { "dependencies": { "@inquirer/core": "^12.0.0", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-OWIH1IyyWqEKIyqC9Xy+Bnga7NkGMovFdo4atYZMUOTRqf6rO2WCv9E/1MyzvOErDBCxs+9UFliRUDc50xs/jw=="],
+    "@inquirer/expand": ["@inquirer/expand@5.1.5", "", { "dependencies": { "@inquirer/core": "^12.0.3", "@inquirer/type": "4.1.1" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-uHuXLmXW+TtIfT/9vSBotypAkqn1n34Ul+CLGPos/xANyO4Ff5xZzkYhbKR4NEcfVK4a9mHQOpwVZzluSHFRGw=="],
 
-    "@inquirer/figures": ["@inquirer/figures@2.0.8", "", {}, "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q=="],
+    "@inquirer/figures": ["@inquirer/figures@2.0.9", "", {}, "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg=="],
 
-    "@inquirer/input": ["@inquirer/input@5.1.3", "", { "dependencies": { "@inquirer/core": "^12.0.0", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-F/BZHtyEzP+HO+IGVd4AjBRgvX/ywm42bx8S0+dENk2YclzE9tJ3X/15THwtT6ehApmKvdYDMsVTuyyDod0gOQ=="],
+    "@inquirer/input": ["@inquirer/input@5.1.6", "", { "dependencies": { "@inquirer/core": "^12.0.3", "@inquirer/type": "4.1.1" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-HtcJhB2QFVXbLuJ5S3syhNbTUVxYvwqV4VRBDkQceBloC9bmTViUoRFP5PbSaDZb3HzfPmpuU/gG4ybVBz4FHA=="],
 
-    "@inquirer/select": ["@inquirer/select@5.2.2", "", { "dependencies": { "@inquirer/ansi": "^2.0.7", "@inquirer/core": "^12.0.0", "@inquirer/figures": "^2.0.8", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RkI8dRHWt+bh04oLixvF1kFzKC7e5rqJoHKkzcqSHATebBXFC6GmrT8ddbVkgSzLV0HnHs2cPFuBINr8otij8Q=="],
+    "@inquirer/select": ["@inquirer/select@5.2.5", "", { "dependencies": { "@inquirer/ansi": "^2.0.8", "@inquirer/core": "^12.0.3", "@inquirer/figures": "^2.0.9", "@inquirer/type": "4.1.1" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-9kc15hr8r/kI+3DO/xLog5nOzTz1jqsHXa6JBFzmQKhkoJ8Slda1I1L/uD8ZSZ9tF1yp79wwXe7mclvX1rqR2Q=="],
 
-    "@inquirer/type": ["@inquirer/type@4.0.7", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="],
+    "@inquirer/type": ["@inquirer/type@4.1.1", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A=="],
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
@@ -1000,13 +1001,13 @@
 
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
-    "@octokit/core": ["@octokit/core@7.0.7", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.4", "@octokit/request": "^10.0.13", "@octokit/request-error": "^7.1.1", "@octokit/types": "^17.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA=="],
+    "@octokit/core": ["@octokit/core@7.0.8", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.5", "@octokit/request": "^10.0.16", "@octokit/request-error": "^7.1.2", "@octokit/types": "^18.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-L7y8eYc+AwxGr2PWI4WFt1VG4TiJ66c26BD16mXpYIlXxG0SMigM1+m4aTSlYyBr5BlQsGAlz8uDCoZN4SEMcg=="],
 
-    "@octokit/endpoint": ["@octokit/endpoint@11.0.4", "", { "dependencies": { "@octokit/types": "^17.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA=="],
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.5", "", { "dependencies": { "@octokit/types": "^18.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-iXa654H3yFafF/ieHkukfbgWo2rmXD2ceD0ZOtrPhw1bc3FDch1d9N/TNs0FQ1/cIbwb7kspUX8jzIs8nzb9DQ=="],
 
-    "@octokit/graphql": ["@octokit/graphql@9.0.4", "", { "dependencies": { "@octokit/request": "^10.0.13", "@octokit/types": "^17.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg=="],
+    "@octokit/graphql": ["@octokit/graphql@9.0.5", "", { "dependencies": { "@octokit/request": "^10.0.16", "@octokit/types": "^18.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-bt/hm03LeU6Vy7FwTrkkC9p3XGT/lBwClglMqxBSe5/q0E5CdJTXeAqEI0vlw89/LF/G6tryTIH8HirZ3prMVg=="],
 
-    "@octokit/openapi-types": ["@octokit/openapi-types@28.0.0", "", {}, "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ=="],
+    "@octokit/openapi-types": ["@octokit/openapi-types@29.0.1", "", {}, "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg=="],
 
     "@octokit/plugin-enterprise-rest": ["@octokit/plugin-enterprise-rest@6.0.1", "", {}, "sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw=="],
 
@@ -1016,37 +1017,37 @@
 
     "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
 
-    "@octokit/request": ["@octokit/request@10.0.15", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.1.1", "@octokit/types": "^17.0.0", "content-type": "^3.0.0", "json-with-bigint": "^3.5.12", "universal-user-agent": "^7.0.2" } }, "sha512-3CBg9aJ0hO9Pjyij8LbK/xYtEaPws9SW7xKz67daPNxQB1q5Y9OMA7DDOG0A6Hwf9ygGu3tvzusg0LXQ8/wAjA=="],
+    "@octokit/request": ["@octokit/request@10.0.16", "", { "dependencies": { "@octokit/endpoint": "^11.0.5", "@octokit/request-error": "^7.1.2", "@octokit/types": "^18.0.0", "content-type": "^3.0.0", "json-with-bigint": "^3.5.12", "universal-user-agent": "^7.0.2" } }, "sha512-A0zWGjHzISIb+9ccG8s0dq7LKO5zVpJLRICjgUb+sJxEWqn8RUHB1rD3AE51+PECvXHIxqZ1VVvs4fHTSD9nUQ=="],
 
-    "@octokit/request-error": ["@octokit/request-error@7.1.1", "", { "dependencies": { "@octokit/types": "^17.0.0" } }, "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA=="],
+    "@octokit/request-error": ["@octokit/request-error@7.1.2", "", { "dependencies": { "@octokit/types": "^18.0.0" } }, "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg=="],
 
     "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
 
-    "@octokit/types": ["@octokit/types@17.0.0", "", { "dependencies": { "@octokit/openapi-types": "^28.0.0" } }, "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q=="],
+    "@octokit/types": ["@octokit/types@18.0.0", "", { "dependencies": { "@octokit/openapi-types": "^29.0.1" } }, "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA=="],
 
-    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GCpf8QuFLsyioVawP5HrMxA1ZRBlu6Hq9RNnSc3UTUWAzIxBso9trjoZczw1HdgpqSssFkszfIV2zmOzFTjhkw=="],
+    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.4.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MXdZkP1featqxZ+/VTXWG1BVjM4OGBehVY2Q88EeUj/7L0UMeCGItmyPYTN+wxvlGJ6F66JEtzsw+GvQWewnag=="],
 
-    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.4.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-cIrhwOr0SPEraewznhC+c/k6TG8bwFn5uZ4EJuXwjiKJLcAF36q7/bGjWkeXSe48JwMcPRUR054JXF7+cRwSSA=="],
+    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.4.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gZTxZuLjkUhAWjTETu3tw0WhsEdNkJ64daj60ybhPf835a2yollV3yTkK9JozvzKPx4TRFzLSl8C+U525pxVbw=="],
 
-    "@oven/bun-freebsd-aarch64": ["@oven/bun-freebsd-aarch64@1.4.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-09x7wnjMR6M5KGBDBhVl2CpfoCIQOkVDbPX2KfIhpXv4N6grbWE7dfLPw/Ydi9gaUMGhU7UKhoz444Nu6RCycA=="],
+    "@oven/bun-freebsd-aarch64": ["@oven/bun-freebsd-aarch64@1.4.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-SMNItMw1Z8QeeQVKnw8jA7xQNkeXdP+OPgin4Wi/QTx/B8RHHLnuZfqmFy7NtVeT2NF0kKYppW4WWd2CCYZjhQ=="],
 
-    "@oven/bun-freebsd-x64": ["@oven/bun-freebsd-x64@1.4.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dRwzti/qJqV1HWplU27iUWUqp+f2DtFSf2yqQKSb+HH2dDOC//Uqd9u/A5h1DMsLszfP5OGP9UwQIKxVwFODaA=="],
+    "@oven/bun-freebsd-x64": ["@oven/bun-freebsd-x64@1.4.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-THbPKXhO54N0DpFRKZNDZpQ7dpbX0bWASuARckAUS9wRtFIHsiY+uULXJvxJGo2YD1YewvXQ4G8Fj7XT5oBCiw=="],
 
-    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Y5yAtCbHK6JjprXEtkdklDQFPADgs+CkfcliyY5g4JJ8baGHyQSrfpSkX3XVJ2C+aBLsdwNDdW+oczMsAwx6uA=="],
+    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3BBP9ovJ2RGHFH6Ae1CAtxNtG1+YY6GD6rmYbsUosoAk9+OEl6zeDQ/k4fBkc6dYOJCtWnx8hUxzNzQATSmvYQ=="],
 
-    "@oven/bun-linux-aarch64-android": ["@oven/bun-linux-aarch64-android@1.4.0", "", { "os": "android", "cpu": "arm64" }, "sha512-HpPIxJfDNPBPhiBNMyZoo/dOLijARfsx5j72vNuLtaTvl0Hh7HUculxjsOQ2WSyGoCgqXMEr1Qqjab1im9u1RA=="],
+    "@oven/bun-linux-aarch64-android": ["@oven/bun-linux-aarch64-android@1.4.2", "", { "os": "android", "cpu": "arm64" }, "sha512-3mZKO2rhsNgbAUtAHC1UKUlF2zTxFraDZT/Elv8wzyH0fJL9h+Iv3TgB9lO63w89PRn3eFe+NRA1bhVgikKNPQ=="],
 
-    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RUjAAkJ/CdNV++zVxyANWshPc73CECYsfhk0fWAkoJjtywxJ2BwXzI6nopBBDMfs0HS+fhRGn6zGwU8ccxLeJg=="],
+    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Sm6y+lSiSFBOtXmnekp5Q6n1tUKlyv71FCPWBc61Cgb14T5eBs8SN/nh4MUCOKzONkI3O+as3MGUgikS4aCBQ=="],
 
-    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Du44zebtPXJujvMLmtIxEQ6ykOhYt7L/Q+YIGVm+Yy+Pj/fpOnq60ggwIpKp/pGAFbYHNiTrA3JTjuZ9MTbZIg=="],
+    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-9/E/UXOTpSo3YsV5g+FhtTd/qTpiWoKuxS12cqtuYA1ssu9fRAoPQnipFgGyck3tWO63iUdxBiygq+kELFawng=="],
 
-    "@oven/bun-linux-x64-android": ["@oven/bun-linux-x64-android@1.4.0", "", { "os": "android", "cpu": "x64" }, "sha512-u++KyLlfMn36yWz+AgJs+fZtS46UFDNpSSZhrcitkytONtNwq0X6Q9BDVEFXxYl/+Eec0xme1rb6MgW+U35WeA=="],
+    "@oven/bun-linux-x64-android": ["@oven/bun-linux-x64-android@1.4.2", "", { "os": "android", "cpu": "x64" }, "sha512-6HC5tzcC79113n2IHCTJMWv+HsQImv4ZFEK2XpYLxY6HbT8tM4cUM2Zv1bHZBQsS3jv/zYBamDJ1UX7If0d5tw=="],
 
-    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-C1Dv+ISL8YKEKM9jAHzNifOcRUoziy6UMxh+yVXjUCP6QnbRhENDHLaIWWkQZJyBLTn0I3xozflorAlHiGzGqA=="],
+    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-vVTKUg1bnPhRP/Hp73jIVoFh2vPFNYEqYX0ERKfZBOQEEHitNAeukZzzuUDZS0SoDCIpuWUGSpd/CDMbjdR+Uw=="],
 
-    "@oven/bun-windows-aarch64": ["@oven/bun-windows-aarch64@1.4.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-FBAYaQpJBP0asgqzL6NFUfjdQqsV+kvTpJ/eWxPKj+RcDgIfPSuE8kvQuPYu5pa8u8JTujYMjmuyvHxVuQsInA=="],
+    "@oven/bun-windows-aarch64": ["@oven/bun-windows-aarch64@1.4.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-8EJ1ST7339WJE3poPW5nBgVW/lWf9HBz4W27ZUNhburKmcBLOByPyE6DP9fHD8FQGm5c+ilUN2hX1mrW0jxq9Q=="],
 
-    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-jRKv1NPLznMSZY5BEWciMF7zv0Tiyo2pQSxAJ3w+YWJ6y3VWNJQQQdLlV5Jx8lbOFDrJdrc9dD3GV17k3BP41A=="],
+    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.4.2", "", { "os": "win32", "cpu": "x64" }, "sha512-+bN6OuVld/9diT/RLSXSW7JE6CvNE3gL9XsAEjULi1nUsXd6DNO6GuA9jNdNb3r8PdJFnYHr5aypNV1Oj3Rd9g=="],
 
     "@sigstore/bundle": ["@sigstore/bundle@4.0.0", "", { "dependencies": { "@sigstore/protobuf-specs": "^0.5.0" } }, "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A=="],
 
@@ -1072,9 +1073,9 @@
 
     "@tufjs/models": ["@tufjs/models@4.1.0", "", { "dependencies": { "@tufjs/canonical-json": "2.0.0", "minimatch": "^10.1.1" } }, "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww=="],
 
-    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
+    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
 
-    "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
+    "@types/node": ["@types/node@26.5.0", "", { "dependencies": { "undici-types": "~8.9.0" } }, "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A=="],
 
     "@types/parse-path": ["@types/parse-path@7.1.0", "", { "dependencies": { "parse-path": "*" } }, "sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q=="],
 
@@ -1132,7 +1133,7 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "argue-cli": ["argue-cli@3.1.0", "", {}, "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw=="],
+    "argue-cli": ["argue-cli@3.2.0", "", {}, "sha512-VipTB0gXgGIFO2Rg9yEVN5wLt2AurJcZqDbgmYSwPwsykhLrQhs240/bfceev4w68lI8JshoOJIk9uW7tFzROw=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -1144,7 +1145,7 @@
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
-    "bun": ["bun@1.4.0", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.4.0", "@oven/bun-darwin-x64": "1.4.0", "@oven/bun-freebsd-aarch64": "1.4.0", "@oven/bun-freebsd-x64": "1.4.0", "@oven/bun-linux-aarch64": "1.4.0", "@oven/bun-linux-aarch64-android": "1.4.0", "@oven/bun-linux-aarch64-musl": "1.4.0", "@oven/bun-linux-x64": "1.4.0", "@oven/bun-linux-x64-android": "1.4.0", "@oven/bun-linux-x64-musl": "1.4.0", "@oven/bun-windows-aarch64": "1.4.0", "@oven/bun-windows-x64": "1.4.0" }, "os": [ "!aix", "!sunos", "!openbsd", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-iRiFkc2W7UVpCyZXO9tod45TP9QCyN19fWqbpeN/jaM/K7uzeHYx/OSPsahMJazGKBgPsnxRt+4Jc43d8BcHZw=="],
+    "bun": ["bun@1.4.2", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.4.2", "@oven/bun-darwin-x64": "1.4.2", "@oven/bun-freebsd-aarch64": "1.4.2", "@oven/bun-freebsd-x64": "1.4.2", "@oven/bun-linux-aarch64": "1.4.2", "@oven/bun-linux-aarch64-android": "1.4.2", "@oven/bun-linux-aarch64-musl": "1.4.2", "@oven/bun-linux-x64": "1.4.2", "@oven/bun-linux-x64-android": "1.4.2", "@oven/bun-linux-x64-musl": "1.4.2", "@oven/bun-windows-aarch64": "1.4.2", "@oven/bun-windows-x64": "1.4.2" }, "os": [ "!aix", "!sunos", "!openbsd", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-TrSXo6HJfIEaczpb3kjX82I2pL47vK1QUNmHRCUdz9IzaOwa9lzOXSWwu2l18YHE3sNfGRapVLd4nNm+22vVVA=="],
 
     "bun-plugin-tailwind": ["bun-plugin-tailwind@0.1.2", "", { "peerDependencies": { "bun": ">=1.0.0" } }, "sha512-41jNC1tZRSK3s1o7pTNrLuQG8kL/0vR/JgiTmZAJ1eHwe0w5j6HFPKeqEk0WAD13jfrUC7+ULuewFBBCoADPpg=="],
 
@@ -1252,7 +1253,7 @@
 
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
-    "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
+    "ip-address": ["ip-address@10.7.0", "", {}, "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
@@ -1336,7 +1337,7 @@
 
     "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
-    "p-map": ["p-map@7.0.6", "", {}, "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg=="],
+    "p-map": ["p-map@7.0.7", "", {}, "sha512-VaWRu2i4FJNRtiRWCuuQRgfQ1B7a6+gMSrO+3j0EQi/k0ULfS9kosRxGoiqwzIjZTDI02tGfk5mXXltLg6QtfQ=="],
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
@@ -1352,13 +1353,13 @@
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
-    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+    "picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "playground": ["playground@workspace:pkg/playground"],
 
-    "postcss-selector-parser": ["postcss-selector-parser@7.1.5", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw=="],
+    "postcss-selector-parser": ["postcss-selector-parser@7.1.6", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw=="],
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
@@ -1388,7 +1389,7 @@
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
-    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+    "socks": ["socks@2.8.10", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ=="],
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
@@ -1412,7 +1413,7 @@
 
     "tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
 
-    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+    "tinyexec": ["tinyexec@1.3.1", "", {}, "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
@@ -1424,9 +1425,9 @@
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
-    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
+    "undici": ["undici@6.28.1", "", {}, "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA=="],
 
-    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+    "undici-types": ["undici-types@8.9.0", "", {}, "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
@@ -1469,8 +1470,6 @@
     "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
     "@octokit/request/content-type": ["content-type@3.0.0", "", {}, "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw=="],
-
-    "@types/bun/bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 

--- a/pkg/bobbin/package.json
+++ b/pkg/bobbin/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
-    "@types/bun": "^1.4.1",
+    "@types/bun": "^1.4.2",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/loom/package.json
+++ b/pkg/loom/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
-    "@types/bun": "^1.4.1",
+    "@types/bun": "^1.4.2",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/bind/package.json
+++ b/pkg/nanolib/bind/package.json
@@ -31,7 +31,7 @@
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@happy-dom/global-registrator": "^20.14.0",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/crypto/package.json
+++ b/pkg/nanolib/crypto/package.json
@@ -28,7 +28,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/debounce/package.json
+++ b/pkg/nanolib/debounce/package.json
@@ -25,7 +25,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/delay/package.json
+++ b/pkg/nanolib/delay/package.json
@@ -30,7 +30,7 @@
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@happy-dom/global-registrator": "^20.14.0",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/env/README.md
+++ b/pkg/nanolib/env/README.md
@@ -24,9 +24,9 @@ console.log(env); // Output: 'development-value' in development mode, 'default-v
 
 ## API
 
-### `getEnv(option: GetEnvValueOption): string`
+### `getEnv(option: GetEnvOption): string`
 
-Retrieves the value of an environment variable.
+Retrieves the value of an environment variable as a string.
 
 **Parameters:**
 
@@ -43,12 +43,38 @@ The value of the environment variable.
 
 An error if the environment variable is not set and no default value is provided.
 
+### `getNumberEnv(option: GetNumberEnvOption): number`
+
+Retrieves the numeric value of an environment variable. Validates that the resolved string or fallback value can be converted to a finite number using `@alwatr/is-number`.
+
+**Parameters:**
+
+- `option`: An object with the following properties:
+  - `name`: The name of the environment variable.
+  - `defaultValue`: The default value (`number` or `string`) to use if the environment variable is not set.
+  - `developmentValue`: The value (`number` or `string`) to use in a development environment.
+
+**Returns:**
+
+The parsed numeric value of the environment variable.
+
+**Throws:**
+
+- An error if the environment variable is not set and no default value is provided.
+- An error if the resolved value cannot be converted to a finite number.
+
 ## Examples
 
-**Basic usage:**
+**Basic string usage:**
 
 ```typescript
 const dbUrl = getEnv({name: 'DATABASE_URL', defaultValue: 'mongodb://localhost:27017'});
+```
+
+**Numeric environment variable:**
+
+```typescript
+const port = getNumberEnv({name: 'PORT', defaultValue: 8080});
 ```
 
 **Development value:**
@@ -59,12 +85,19 @@ const apiUrl = getEnv({
   defaultValue: 'https://api.example.com',
   developmentValue: 'http://localhost:3000',
 });
+
+const devPort = getNumberEnv({
+  name: 'PORT',
+  defaultValue: 80,
+  developmentValue: 8080,
+});
 ```
 
 **Required environment variable:**
 
 ```typescript
 const apiKey = getEnv({name: 'API_KEY'}); // Throws an error if API_KEY is not set
+const maxRetries = getNumberEnv({name: 'MAX_RETRIES'}); // Throws if unset or not a valid number
 ```
 
 ## Sponsors

--- a/pkg/nanolib/env/package.json
+++ b/pkg/nanolib/env/package.json
@@ -22,6 +22,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@alwatr/is-number": "workspace:*",
     "@alwatr/platform-info": "workspace:*"
   },
   "devDependencies": {

--- a/pkg/nanolib/env/package.json
+++ b/pkg/nanolib/env/package.json
@@ -29,7 +29,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/env/src/main.test.js
+++ b/pkg/nanolib/env/src/main.test.js
@@ -1,0 +1,127 @@
+import {getEnv, getNumberEnv} from '@alwatr/env';
+import {platformInfo} from '@alwatr/platform-info';
+
+describe('@alwatr/env', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {...originalEnv};
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('getEnv', () => {
+    it('should return value from process.env', () => {
+      process.env.TEST_ENV_VAR = 'hello';
+      expect(getEnv({name: 'TEST_ENV_VAR'})).toBe('hello');
+    });
+
+    it('should return defaultValue when env var is not set', () => {
+      delete process.env.TEST_ENV_VAR;
+      expect(getEnv({name: 'TEST_ENV_VAR', defaultValue: 'default'})).toBe('default');
+    });
+
+    it('should treat empty string as undefined and use defaultValue', () => {
+      process.env.TEST_ENV_VAR = '';
+      expect(getEnv({name: 'TEST_ENV_VAR', defaultValue: 'fallback'})).toBe('fallback');
+    });
+
+    it('should throw error when env var is missing and no default provided', () => {
+      delete process.env.MISSING_VAR;
+      expect(() => getEnv({name: 'MISSING_VAR'})).toThrow('Environment variable "MISSING_VAR" is required.');
+    });
+
+    it('should return developmentValue in development mode', () => {
+      delete process.env.TEST_ENV_VAR;
+      const isDev = platformInfo.development;
+      try {
+        platformInfo.development = true;
+        expect(getEnv({name: 'TEST_ENV_VAR', defaultValue: 'prod', developmentValue: 'dev'})).toBe('dev');
+      } finally {
+        platformInfo.development = isDev;
+      }
+    });
+  });
+
+  describe('getNumberEnv', () => {
+    it('should return parsed number from process.env', () => {
+      process.env.TEST_NUM = '1234';
+      expect(getNumberEnv({name: 'TEST_NUM'})).toBe(1234);
+    });
+
+    it('should parse negative and float numbers', () => {
+      process.env.TEST_FLOAT = '-12.34';
+      expect(getNumberEnv({name: 'TEST_FLOAT'})).toBe(-12.34);
+    });
+
+    it('should return 0 correctly from process.env', () => {
+      process.env.TEST_ZERO = '0';
+      expect(getNumberEnv({name: 'TEST_ZERO'})).toBe(0);
+    });
+
+    it('should return numeric defaultValue when unset', () => {
+      delete process.env.TEST_NUM;
+      expect(getNumberEnv({name: 'TEST_NUM', defaultValue: 8080})).toBe(8080);
+    });
+
+    it('should return string defaultValue converted to number', () => {
+      delete process.env.TEST_NUM;
+      expect(getNumberEnv({name: 'TEST_NUM', defaultValue: '3000'})).toBe(3000);
+    });
+
+    it('should handle 0 as defaultValue', () => {
+      delete process.env.TEST_NUM;
+      expect(getNumberEnv({name: 'TEST_NUM', defaultValue: 0})).toBe(0);
+    });
+
+    it('should treat empty string as undefined and use defaultValue', () => {
+      process.env.TEST_NUM = '';
+      expect(getNumberEnv({name: 'TEST_NUM', defaultValue: 5000})).toBe(5000);
+    });
+
+    it('should return developmentValue in development mode', () => {
+      delete process.env.TEST_NUM;
+      const isDev = platformInfo.development;
+      try {
+        platformInfo.development = true;
+        expect(getNumberEnv({name: 'TEST_NUM', defaultValue: 80, developmentValue: 8080})).toBe(8080);
+        expect(getNumberEnv({name: 'TEST_NUM', defaultValue: 80, developmentValue: '9000'})).toBe(9000);
+      } finally {
+        platformInfo.development = isDev;
+      }
+    });
+
+    it('should throw error when env var is missing and no default provided', () => {
+      delete process.env.MISSING_NUM;
+      expect(() => getNumberEnv({name: 'MISSING_NUM'})).toThrow('Environment variable "MISSING_NUM" is required.');
+    });
+
+    it('should throw error when env var is not a valid number', () => {
+      process.env.INVALID_NUM = 'not-a-number';
+      expect(() => getNumberEnv({name: 'INVALID_NUM'})).toThrow(
+        'Environment variable "INVALID_NUM" must be a valid number, received: "not-a-number".',
+      );
+    });
+
+    it('should throw error for NaN or Infinity in env var', () => {
+      process.env.NAN_NUM = 'NaN';
+      expect(() => getNumberEnv({name: 'NAN_NUM'})).toThrow(
+        'Environment variable "NAN_NUM" must be a valid number, received: "NaN".',
+      );
+
+      process.env.INF_NUM = 'Infinity';
+      expect(() => getNumberEnv({name: 'INF_NUM'})).toThrow(
+        'Environment variable "INF_NUM" must be a valid number, received: "Infinity".',
+      );
+    });
+
+    it('should throw error when defaultValue is not a valid number', () => {
+      delete process.env.TEST_INVALID_DEFAULT;
+      expect(() => getNumberEnv({name: 'TEST_INVALID_DEFAULT', defaultValue: 'abc'})).toThrow(
+        'Environment variable "TEST_INVALID_DEFAULT" must be a valid number, received: "abc".',
+      );
+    });
+  });
+});

--- a/pkg/nanolib/env/src/main.ts
+++ b/pkg/nanolib/env/src/main.ts
@@ -1,3 +1,4 @@
+import {toNumber} from '@alwatr/is-number';
 import {platformInfo} from '@alwatr/platform-info';
 
 /**
@@ -18,24 +19,91 @@ export type GetEnvOption = {
 
   /**
    * The value to use in a development environment.
-   * It will be overwrite the default value in development mode and completely ignored in production mode.
+   * It will overwrite the default value in development mode and completely ignored in production mode.
    */
   developmentValue?: string;
 };
 
+/**
+ * Parameters for retrieving a numeric environment variable value.
+ */
+export type GetNumberEnvOption = {
+  /**
+   * The name of the environment variable.
+   */
+  name: string;
+
+  /**
+   * The default value to use if the environment variable is not set.
+   * If not provided, the environment variable is required and an error will be thrown if it is not set.
+   * Except in development mode, where the development value will be used instead if provided.
+   */
+  defaultValue?: number;
+
+  /**
+   * The value to use in a development environment.
+   * It will overwrite the default value in development mode and completely ignored in production mode.
+   */
+  developmentValue?: number;
+};
+
+/**
+ * Retrieves the string value of an environment variable.
+ *
+ * @param option - Configuration options for retrieving the environment variable.
+ * @returns The string value of the environment variable.
+ * @throws Error if the environment variable is required and not set.
+ */
 export function getEnv(option: GetEnvOption): string {
   let value = process.env[option.name];
   if (value === '') value = undefined; // empty string is considered as undefined in environment variables
 
-  if (platformInfo.development === true) {
+  if (platformInfo.development) {
     value ??= option.developmentValue ?? option.defaultValue;
   } else {
     value ??= option.defaultValue;
   }
 
-  if (value === undefined) {
+  if (value == null) {
     throw new Error(`Environment variable "${option.name}" is required.`);
   }
 
   return value;
+}
+
+/**
+ * Retrieves the numeric value of an environment variable.
+ *
+ * Uses `@alwatr/is-number` to validate and convert the resolved value into a finite number.
+ *
+ * @param option - Configuration options for retrieving the numeric environment variable.
+ * @returns The parsed number value.
+ * @throws Error if the environment variable is required and not set.
+ * @throws Error if the resolved value cannot be converted to a finite number.
+ *
+ * @example
+ * ```ts
+ * const port = getNumberEnv({name: 'PORT', defaultValue: 8080});
+ * ```
+ */
+export function getNumberEnv(option: GetNumberEnvOption): number {
+  let value: string | number | undefined = process.env[option.name];
+  if (value === '') value = undefined; // empty string is considered as undefined in environment variables
+
+  if (platformInfo.development) {
+    value ??= option.developmentValue ?? option.defaultValue;
+  } else {
+    value ??= option.defaultValue;
+  }
+
+  if (value == null) {
+    throw new Error(`Environment variable "${option.name}" is required.`);
+  }
+
+  const num = toNumber(value);
+  if (num === null) {
+    throw new Error(`Environment variable "${option.name}" must be a valid number, received: "${value}".`);
+  }
+
+  return num;
 }

--- a/pkg/nanolib/exit-hook/package.json
+++ b/pkg/nanolib/exit-hook/package.json
@@ -25,7 +25,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/global-this/package.json
+++ b/pkg/nanolib/global-this/package.json
@@ -28,7 +28,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/logger/package.json
+++ b/pkg/nanolib/logger/package.json
@@ -25,7 +25,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/node-fs/package.json
+++ b/pkg/nanolib/node-fs/package.json
@@ -30,7 +30,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/platform-info/package.json
+++ b/pkg/nanolib/platform-info/package.json
@@ -25,7 +25,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanolib/random/src/main.test.js
+++ b/pkg/nanolib/random/src/main.test.js
@@ -1,3 +1,4 @@
+import {describe, test, expect} from 'bun:test';
 import {
   randNumber,
   randInteger,

--- a/pkg/nanolib/signal/src/operators/filter.ts
+++ b/pkg/nanolib/signal/src/operators/filter.ts
@@ -62,11 +62,15 @@ export function createFilteredSignal<T>(
     },
   });
 
-  const subscription = sourceSignal.subscribe((newValue) => {
-    if (predicate(newValue)) {
-      internalSignal.set(newValue);
-    }
-  });
+  const subscription = sourceSignal.subscribe(
+    (newValue) => {
+      if (internalSignal.isDestroyed) return;
+      if (predicate(newValue)) {
+        internalSignal.set(newValue);
+      }
+    },
+    {receivePrevious: false},
+  );
 
   return internalSignal;
 }

--- a/pkg/nanotron-old/api-server/package.json
+++ b/pkg/nanotron-old/api-server/package.json
@@ -28,7 +28,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanotron-old/pre-handlers/package.json
+++ b/pkg/nanotron-old/pre-handlers/package.json
@@ -28,7 +28,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nanotron/package.json
+++ b/pkg/nanotron/package.json
@@ -30,7 +30,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nitrobase-old/engine/package.json
+++ b/pkg/nitrobase-old/engine/package.json
@@ -35,7 +35,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nitrobase-old/helper/package.json
+++ b/pkg/nitrobase-old/helper/package.json
@@ -30,7 +30,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nitrobase-old/reference/package.json
+++ b/pkg/nitrobase-old/reference/package.json
@@ -32,7 +32,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nitrobase-old/types/package.json
+++ b/pkg/nitrobase-old/types/package.json
@@ -28,7 +28,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nitrobase-old/user-management/package.json
+++ b/pkg/nitrobase-old/user-management/package.json
@@ -33,7 +33,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/nitrobase/package.json
+++ b/pkg/nitrobase/package.json
@@ -38,7 +38,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "typescript": "^7.0.2"
   },
   "scripts": {

--- a/pkg/weaver/package.json
+++ b/pkg/weaver/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
-    "@types/bun": "^1.4.1",
+    "@types/bun": "^1.4.2",
     "typescript": "^7.0.2"
   },
   "scripts": {


### PR DESCRIPTION
## Description

Add `getNumberEnv` function to retrieve numeric environment variables, enhancing the existing `getEnv` functionality. Include tests for both functions and update the documentation accordingly. Introduce the `@alwatr/is-number` dependency for validation and update relevant type definitions.

